### PR TITLE
Feat: API Response Model add

### DIFF
--- a/happiness-app-api/build.gradle.kts
+++ b/happiness-app-api/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("org.postgresql:postgresql")
+    runtimeOnly("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/happiness-app-api/src/main/kotlin/com/happiness/api/v1/content/adapter/in/presentation/ApiResponse.kt
+++ b/happiness-app-api/src/main/kotlin/com/happiness/api/v1/content/adapter/in/presentation/ApiResponse.kt
@@ -1,0 +1,23 @@
+package com.happiness.api.v1.content.adapter.`in`.presentation
+
+import domain.ResultCode
+
+data class ApiResponse<T>(
+    val code: String,
+    val message: String,
+    val data: T? = null
+) {
+    companion object {
+        fun <T> empty(): ApiResponse<T> {
+            return ApiResponse("", "", null)
+        }
+
+        fun <T> success() = ApiResponse<T>(ResultCode.SUCCESS.name, ResultCode.SUCCESS.message, null)
+
+        fun <T> success(data: T) = ApiResponse(ResultCode.SUCCESS.name, ResultCode.SUCCESS.message, data)
+
+        fun <T> failure(code: String, message: String) = ApiResponse<T>(code, message, null)
+
+        fun <T> failure(resultCode: ResultCode) = ApiResponse<T>(resultCode.name, resultCode.message, null)
+    }
+}

--- a/happiness-app-api/src/main/kotlin/com/happiness/api/v1/content/adapter/in/presentation/ContentGenerateController.kt
+++ b/happiness-app-api/src/main/kotlin/com/happiness/api/v1/content/adapter/in/presentation/ContentGenerateController.kt
@@ -5,23 +5,26 @@ import com.happiness.api.v1.content.application.port.`in`.ContentGenerateUseCase
 import com.happiness.api.v1.content.application.port.command.ContentGenerateCommand
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import javax.validation.Valid
 
+@RequestMapping("/api/v1/content")
 @RestController
 class ContentGenerateController(
-    private val contentGenerateUseCase: ContentGenerateUseCase
+    //private val contentGenerateUseCase: ContentGenerateUseCase
 ) {
 
-    @PostMapping("v1/content")
+    @PostMapping
     fun generate(
         @RequestBody @Valid contentGenerateRequestDto: ContentGenerateRequestDto
     ): String {
-        contentGenerateUseCase.generate(
-            ContentGenerateCommand().apply {
+//        contentGenerateUseCase.generate(
+//            ContentGenerateCommand().apply {
+//
+//            }
+//        )
 
-            }
-        )
         return "1"
     }
 }

--- a/happiness-app-api/src/main/kotlin/com/happiness/api/v1/content/adapter/in/presentation/ContentQueryController.kt
+++ b/happiness-app-api/src/main/kotlin/com/happiness/api/v1/content/adapter/in/presentation/ContentQueryController.kt
@@ -1,13 +1,15 @@
 package com.happiness.api.v1.content.adapter.`in`.presentation
 
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@RequestMapping("/api/v1/content")
 @RestController
 class ContentQueryController {
 
-    @GetMapping("v1/content")
-    fun query(): String {
-        return "1"
+    @GetMapping
+    fun query(): ApiResponse<String> {
+        return ApiResponse.success()
     }
 }

--- a/happiness-app-api/src/main/resources/application-local.yml
+++ b/happiness-app-api/src/main/resources/application-local.yml
@@ -11,7 +11,7 @@ spring:
     show-sql: true
 
   datasource:
-    url: jdbc:h2:tcp://localhost/~/database/h2-database
+    url: jdbc:h2:mem:happy-db
     username: sa
     password:
     driver-class-name: org.h2.Driver

--- a/happiness-common/src/main/kotlin/domain/ResultCode.kt
+++ b/happiness-common/src/main/kotlin/domain/ResultCode.kt
@@ -1,0 +1,10 @@
+package domain
+
+enum class ResultCode(val message: String = "") {
+    SUCCESS("성공"),
+    UNAUTHORIZED("인증 실패"),
+    FORBIDDEN("권한 없음"),
+    BAD_REQUEST("요청에 오류가 있습니다"),
+    INTERNAL_SERVER_ERROR("서버 에러"),
+    ;
+}


### PR DESCRIPTION
## 작업사항
- Controller에서 Client로 반환할 때 사용할 `ApiResponse` Class를 작성하였습니다. 

```json
{
  "code": "SUCCESS",
  "message": "성공",
  "data": null
}
```

- 예를들면, `HTTP Response Body`가 없다면 위와 같이 응답이 오게 됩니다. code에 int 값으로 200, 201 을 보내줄지 아니면 HTTP Header로만 HTTP Status Code를 관리할지, message는 사용할지 말지 등등 추후에 구체적으로 정해보면 좋을 거 같습니다!

## 변경로직
- 이유를 모르지만 `ContentGenerateUseCase`가 `Bean`으로 등록할 수 없다는 에러가 나서 일단 주석처리를 해놓았습니다,, `ComponentScan` 대상이라 생각하는데 에러가 발생하네요 ㅠ,ㅠ 

![스크린샷 2021-12-12 오후 10 59 45](https://user-images.githubusercontent.com/45676906/145715377-6acfcaaf-64b9-45c0-8a90-81fdc8a89fcf.png)


## 확인해야하는 사항
- [ ] 코틀린스럽게(?) 작성 하셨나요?
- [ ] 테스트 코드를 작성 하셨나요?
- [ ] 테스트는 충분히 확인 하셨나요?
